### PR TITLE
Fixed Surface Hub app applicability table

### DIFF
--- a/intune/apps/apps-windows-10-app-deploy.md
+++ b/intune/apps/apps-windows-10-app-deploy.md
@@ -55,7 +55,7 @@ Specific app types are supported based on the version of Windows 10 that your us
 | Office C2R | No | Yes | Yes | Yes | Yes | No | No | No | No | No |
 | LOB: APPX/MSIX | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | MSFB Offline | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| MSFB Online | Yes | Yes | Yes | Yes | Yes | Yes | RS4+ | Yes | Yes | Yes |
+| MSFB Online | Yes | Yes | Yes | Yes | Yes | Yes | RS4+ | No | Yes | Yes |
 | Web Apps | Yes | Yes | Yes | Yes | Yes | Yes | Yes<sup>1 | Yes<sup>1 | Yes | Yes |
 | Store Link | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 


### PR DESCRIPTION
Windows Team, the Surface Hub OS, doesn't support MSFB online licensed app installs.